### PR TITLE
Add per-file constant load triples

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ SM_00002:
 ```
 
 The values are stored for consumption by future preprocessing steps. Their
-interpretation is TBD; see `multimeter` `base_variation`.
+interpretation is TBD.
 
 ### 3. Run the pipeline
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,22 @@ controls only the energy to power scaling. `drop_negative_deltas` is likewise
 allowed in every mode but is applied only to `cumulative_energy`. When omitted
 for that mode, negative deltas are dropped by default.
 
+#### Per-file constant loads
+
+Optional constant-load triples can be stored by CSV file stem in
+`constant_loads.yml` at the repository root:
+
+```yaml
+SM_00001:
+  - [330.0, 20, 6]
+SM_00002:
+  - [150, 24, 8]
+  - [80.0, 12, 2]
+```
+
+The values are stored for consumption by future preprocessing steps. Their
+interpretation is TBD; see `multimeter` `base_variation`.
+
 ### 3. Run the pipeline
 
 ```bash

--- a/constant_loads.yml
+++ b/constant_loads.yml
@@ -1,0 +1,5 @@
+# Maps input file stems (CSV names in data/raw without extension) to a list
+# of [value, int, int] constant load triples, e.g.:
+#
+# SM_00001:
+#   - [330.0, 20, 6]

--- a/src/preprocessing/constant_loads.py
+++ b/src/preprocessing/constant_loads.py
@@ -1,0 +1,71 @@
+import math
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+CONSTANT_LOADS_FILE = ROOT_DIR / "constant_loads.yml"
+
+
+def load_constant_loads(
+    path: Path | None = None,
+) -> dict[str, list[tuple[float, int, int]]]:
+    constant_loads_path = CONSTANT_LOADS_FILE if path is None else path
+    if not constant_loads_path.exists():
+        return {}
+
+    with open(constant_loads_path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+
+    if data is None:
+        return {}
+    if not isinstance(data, Mapping):
+        raise ValueError("constant loads must be a mapping of file stems to lists.")
+
+    result: dict[str, list[tuple[float, int, int]]] = {}
+    for key, triples in data.items():
+        if not isinstance(key, str):
+            raise ValueError(f"constant loads key {key!r} must be a string.")
+        if not isinstance(triples, list):
+            raise ValueError(f"constant loads entry {key!r} must be a list.")
+
+        normalized_triples: list[tuple[float, int, int]] = []
+        for index, triple in enumerate(triples):
+            if (
+                not isinstance(triple, Sequence)
+                or isinstance(triple, str | bytes)
+                or len(triple) != 3
+            ):
+                raise ValueError(
+                    f"constant loads entry {key!r} triple {index} must contain "
+                    "exactly 3 elements."
+                )
+
+            value, second, third = triple
+            if isinstance(value, bool) or not isinstance(value, int | float):
+                raise ValueError(
+                    f"constant loads entry {key!r} triple {index} element 0 "
+                    "must be a number."
+                )
+            if not math.isfinite(value):
+                raise ValueError(
+                    f"constant loads entry {key!r} triple {index} element 0 "
+                    "must be finite."
+                )
+            if isinstance(second, bool) or not isinstance(second, int):
+                raise ValueError(
+                    f"constant loads entry {key!r} triple {index} element 1 "
+                    "must be an integer."
+                )
+            if isinstance(third, bool) or not isinstance(third, int):
+                raise ValueError(
+                    f"constant loads entry {key!r} triple {index} element 2 "
+                    "must be an integer."
+                )
+
+            normalized_triples.append((float(value), second, third))
+
+        result[key] = normalized_triples
+
+    return result

--- a/src/preprocessing/constant_loads.py
+++ b/src/preprocessing/constant_loads.py
@@ -27,7 +27,9 @@ def load_constant_loads(
     for key, triples in data.items():
         if not isinstance(key, str):
             raise ValueError(f"constant loads key {key!r} must be a string.")
-        if not isinstance(triples, list):
+        if triples is None:
+            triples = []
+        elif not isinstance(triples, list):
             raise ValueError(f"constant loads entry {key!r} must be a list.")
 
         normalized_triples: list[tuple[float, int, int]] = []

--- a/tests/test_constant_loads.py
+++ b/tests/test_constant_loads.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+import pytest
+
+from src.preprocessing.constant_loads import load_constant_loads
+
+
+def test_load_constant_loads_parses_and_normalizes_valid_file(tmp_path: Path):
+    path = tmp_path / "constant_loads.yml"
+    path.write_text(
+        "SM_00001:\n"
+        "  - [330, 20, 6]\n"
+        "SM_00002:\n"
+        "  - [150.5, 24, 8]\n"
+        "  - [80.0, 12, 2]\n",
+        encoding="utf-8",
+    )
+
+    assert load_constant_loads(path) == {
+        "SM_00001": [(330.0, 20, 6)],
+        "SM_00002": [(150.5, 24, 8), (80.0, 12, 2)],
+    }
+
+
+def test_load_constant_loads_missing_file_returns_empty_mapping(tmp_path: Path):
+    assert load_constant_loads(tmp_path / "missing.yml") == {}
+
+
+def test_load_constant_loads_empty_file_returns_empty_mapping(tmp_path: Path):
+    path = tmp_path / "constant_loads.yml"
+    path.write_text("", encoding="utf-8")
+
+    assert load_constant_loads(path) == {}
+
+
+def test_file_stem_without_entry_uses_mapping_default(tmp_path: Path):
+    path = tmp_path / "constant_loads.yml"
+    path.write_text("SM_00001:\n  - [330, 20, 6]\n", encoding="utf-8")
+
+    constant_loads = load_constant_loads(path)
+
+    assert constant_loads.get("SM_99999", []) == []
+
+
+def test_load_constant_loads_rejects_non_mapping_top_level(tmp_path: Path):
+    path = tmp_path / "constant_loads.yml"
+    path.write_text("- [330, 20, 6]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be a mapping"):
+        load_constant_loads(path)
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        "[330, 20]",
+        "[not-a-number, 20, 6]",
+        "[true, 20, 6]",
+        "[330, 20.5, 6]",
+        "[330, 20, 6.5]",
+        "[330, false, 6]",
+        "[330, 20, true]",
+        "[.inf, 20, 6]",
+    ],
+)
+def test_load_constant_loads_rejects_invalid_triples(tmp_path: Path, entry: str):
+    path = tmp_path / "constant_loads.yml"
+    path.write_text(f"SM_BAD:\n  - {entry}\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="SM_BAD"):
+        load_constant_loads(path)
+
+
+def test_load_constant_loads_rejects_non_list_entry(tmp_path: Path):
+    path = tmp_path / "constant_loads.yml"
+    path.write_text("SM_BAD: invalid\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="SM_BAD"):
+        load_constant_loads(path)
+
+
+def test_load_constant_loads_rejects_non_string_key(tmp_path: Path):
+    path = tmp_path / "constant_loads.yml"
+    path.write_text("1:\n  - [330, 20, 6]\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="1"):
+        load_constant_loads(path)

--- a/tests/test_constant_loads.py
+++ b/tests/test_constant_loads.py
@@ -33,6 +33,13 @@ def test_load_constant_loads_empty_file_returns_empty_mapping(tmp_path: Path):
     assert load_constant_loads(path) == {}
 
 
+def test_load_constant_loads_null_entry_returns_empty_list(tmp_path: Path):
+    path = tmp_path / "constant_loads.yml"
+    path.write_text("SM_00001:\n", encoding="utf-8")
+
+    assert load_constant_loads(path) == {"SM_00001": []}
+
+
 def test_file_stem_without_entry_uses_mapping_default(tmp_path: Path):
     path = tmp_path / "constant_loads.yml"
     path.write_text("SM_00001:\n  - [330, 20, 6]\n", encoding="utf-8")


### PR DESCRIPTION
Closes #125. Adds constant_loads.yml mapping input file stems to (float, int, int) triples, plus a loader module with validation.